### PR TITLE
Change prime queue size

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -465,7 +465,7 @@ Internally we record calculations of the critical
 epsilon, since the goal is to compute it for a very
 small subset of factors.
 */
-boost::circular_buffer<uint64_t> PrimeQueue(4096);
+boost::circular_buffer<uint64_t> PrimeQueue(2048);
 primesieve::iterator PrimeQueueProducer;
 struct PrimeQueueEpsilonGroup
 {

--- a/Search.cpp
+++ b/Search.cpp
@@ -465,7 +465,7 @@ Internally we record calculations of the critical
 epsilon, since the goal is to compute it for a very
 small subset of factors.
 */
-boost::circular_buffer<uint64_t> PrimeQueue(2048);
+boost::circular_buffer<uint64_t> PrimeQueue(8192);
 primesieve::iterator PrimeQueueProducer;
 struct PrimeQueueEpsilonGroup
 {


### PR DESCRIPTION
Increasing prime queue size 2x sped up code by about 7%.