### PR TITLE
Streamline muls

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -544,50 +544,94 @@ uint64_t AddPrimeFactors()
             mpfr_init2(mpfr_temp1, Precision);
             mpfr_init2(mpfr_temp2, Precision);
             mpfr_init2(mpfr_temp3, Precision);
-            bool TryFastGroup = true;
+
+
+            // bool TryFastGroup = true;
+
+
             while(this_idx > PrimeQueueEpsilonStack.top().index)
             {
+
+                // Iterate
                 const uint64_t BunchSize = 64;
-                if(TryFastGroup and
+                FastBigFloat<3> lhs_update_rndd;
+                lhs_update_rndd.set_ui(1);
+                FastBigFloat<3> lhs_update_rndu;
+                lhs_update_rndu.set_ui(1);
+                FastBigFloat<3> rhs_update_rndd;
+                rhs_update_rndd.set_ui(1);
+                FastBigFloat<3> rhs_update_rndu;
+                rhs_update_rndu.set_ui(1);
+
+                FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;
+                FastBigFloat<3> lhs_update_rndu_test = lhs_update_rndu;
+                FastBigFloat<3> rhs_update_rndd_test = rhs_update_rndd;
+                FastBigFloat<3> rhs_update_rndu_test = rhs_update_rndu;
+
+                while(
+///TryFastGroup and
                    this_idx - PrimeQueueEpsilonStack.top().index >= BunchSize)
                 {
                     cnt_FastBunchMul++;
-                    FastBigFloat<3> lhs_update_rndd;
-                    lhs_update_rndd.set_ui(1);
-                    FastBigFloat<3> lhs_update_rndu;
-                    lhs_update_rndu.set_ui(1);
-                    FastBigFloat<3> rhs_update_rndd;
-                    rhs_update_rndd.set_ui(1);
-                    FastBigFloat<3> rhs_update_rndu;
-                    rhs_update_rndu.set_ui(1);
 
                     for(size_t i = this_idx - BunchSize;
                         i < this_idx;
                         i++)
                     {
-                        lhs_update_rndd.mul_ui_rndd(PrimeQueue[i]+1);
-                        lhs_update_rndu.mul_ui_rndu(PrimeQueue[i]+1);
-                        rhs_update_rndd.mul_ui_rndd(PrimeQueue[i]);
-                        rhs_update_rndu.mul_ui_rndu(PrimeQueue[i]);
+                        lhs_update_rndd_test.mul_ui_rndd(PrimeQueue[i]+1);
+                        lhs_update_rndu_test.mul_ui_rndu(PrimeQueue[i]+1);
+                        rhs_update_rndd_test.mul_ui_rndd(PrimeQueue[i]);
+                        rhs_update_rndu_test.mul_ui_rndu(PrimeQueue[i]);
                     }
-                    lhs_update_rndu.get_rndu(mpfr_temp1);
+
+                    // Check if test values indicate possible violation of bound.
+                    lhs_update_rndu_test.get_rndu(mpfr_temp1);
                     mpfr_mul(mpfr_temp1, mpfr_temp1, LHS_rndu, MPFR_RNDU);
-                    rhs_update_rndd.get_rndd(mpfr_temp3);
+                    rhs_update_rndd_test.get_rndd(mpfr_temp3);
                     mpfr_mul(mpfr_temp2, mpfr_temp3, NloglogN_rndd, MPFR_RNDD);
+
                     if(mpfr_less_p(mpfr_temp1, mpfr_temp2))
                     {
-                        mpfr_swap(mpfr_temp1, LHS_rndu);
-                        mpfr_swap(mpfr_temp2, NloglogN_rndd);
-                        mpfr_mul(Number_rndd, Number_rndd, mpfr_temp3, MPFR_RNDD);
-                        lhs_update_rndd.get_rndd(mpfr_temp1);
-                        mpfr_mul(LHS_rndd, mpfr_temp1, LHS_rndd, MPFR_RNDD);
-                        rhs_update_rndu.get_rndu(mpfr_temp1);
-                        mpfr_mul(Number_rndu, Number_rndu, mpfr_temp1, MPFR_RNDU);
+                        // LHS < RHS is guaranteed.
+                        // Save current progress and keep going.
+                        lhs_update_rndd = lhs_update_rndd_test;
+                        lhs_update_rndu = lhs_update_rndu_test;
+                        rhs_update_rndd = rhs_update_rndd_test;
+                        rhs_update_rndu = rhs_update_rndu_test;
                         this_idx -= BunchSize;
                         cnt_NumUniquePrimeFactors += BunchSize;
                         Number_factors.back().PrimeHi = PrimeQueue[this_idx];
                         cnt_NumPrimeFactors += BunchSize;
                         cnt_FastBunchMul_keep++;
+                    }
+                    else
+                    {
+                        // Possibly LHS >= RHS.
+                        // We need to drop that last bunch and go more carefully.
+                        break;
+                    }
+                }
+
+                // Lock in the updates
+                lhs_update_rndu.get_rndu(mpfr_temp1);
+                mpfr_mul(LHS_rndu, mpfr_temp1, LHS_rndu, MPFR_RNDU);
+                rhs_update_rndd.get_rndd(mpfr_temp3);
+                mpfr_mul(NloglogN_rndd, mpfr_temp3, NloglogN_rndd, MPFR_RNDD);
+                mpfr_mul(Number_rndd, Number_rndd, mpfr_temp3, MPFR_RNDD);
+                lhs_update_rndd.get_rndd(mpfr_temp1);
+                mpfr_mul(LHS_rndd, mpfr_temp1, LHS_rndd, MPFR_RNDD);
+                rhs_update_rndu.get_rndu(mpfr_temp1);
+                mpfr_mul(Number_rndu, Number_rndu, mpfr_temp1, MPFR_RNDU);
+                        
+
+
+
+Then the next loop is while no logs are recomputed.
+
+
+
+
+     
                         continue; // Jumps back to start of loop.
                     }
                     else

--- a/Search.cpp
+++ b/Search.cpp
@@ -612,7 +612,7 @@ uint64_t AddPrimeFactors()
                     }
                 }
 
-                // Lock in the updates
+                // Lock in the updates from bunches.
                 lhs_update_rndu.get_rndu(mpfr_temp1);
                 mpfr_mul(LHS_rndu, mpfr_temp1, LHS_rndu, MPFR_RNDU);
                 rhs_update_rndd.get_rndd(mpfr_temp3);
@@ -623,35 +623,25 @@ uint64_t AddPrimeFactors()
                 rhs_update_rndu.get_rndu(mpfr_temp1);
                 mpfr_mul(Number_rndu, Number_rndu, mpfr_temp1, MPFR_RNDU);
                         
-
-
-
-Then the next loop is while no logs are recomputed.
-
-
-
-
-     
-                        continue; // Jumps back to start of loop.
-                    }
-                    else
+                // Iterate factor by factor until we update logs.
+                while(this_idx > PrimeQueueEpsilonStack.top().index)
+                {
+                    this_idx--;
+                    uint64_t this_p = PrimeQueue[this_idx];
+                    mpfr_mul_ui(Number_rndd, Number_rndd, this_p, MPFR_RNDD);
+                    mpfr_mul_ui(Number_rndu, Number_rndu, this_p, MPFR_RNDU);
+                    mpfr_mul_ui(NloglogN_rndd, NloglogN_rndd, this_p, MPFR_RNDD);
+                    mpfr_mul_ui(LHS_rndd, LHS_rndd, this_p+1, MPFR_RNDD);
+                    mpfr_mul_ui(LHS_rndu, LHS_rndu, this_p+1, MPFR_RNDU);
+                    Number_factors.back().PrimeHi = this_p;
+                    cnt_NumUniquePrimeFactors++;
+                    bool LogsWereRecomputed =  CheckNumber();
+                    if(LogsWereRecomputed)
                     {
-                        // Would be wasteful to try again before
-                        // logarithms are updated.
-                        TryFastGroup = false;
+                        // Maybe we can do more fast bunches.
+                        break;
                     }
                 }
-                this_idx--;
-                uint64_t this_p = PrimeQueue[this_idx];
-                mpfr_mul_ui(Number_rndd, Number_rndd, this_p, MPFR_RNDD);
-                mpfr_mul_ui(Number_rndu, Number_rndu, this_p, MPFR_RNDU);
-                mpfr_mul_ui(NloglogN_rndd, NloglogN_rndd, this_p, MPFR_RNDD);
-                mpfr_mul_ui(LHS_rndd, LHS_rndd, this_p+1, MPFR_RNDD);
-                mpfr_mul_ui(LHS_rndu, LHS_rndu, this_p+1, MPFR_RNDU);
-                Number_factors.back().PrimeHi = this_p;
-                cnt_NumUniquePrimeFactors++;
-                bool LogsWereRecomputed =  CheckNumber();
-                TryFastGroup = TryFastGroup or LogsWereRecomputed;
             }
             mpfr_clear(mpfr_temp1);
             mpfr_clear(mpfr_temp2);

--- a/Search.cpp
+++ b/Search.cpp
@@ -545,13 +545,8 @@ uint64_t AddPrimeFactors()
             mpfr_init2(mpfr_temp2, Precision);
             mpfr_init2(mpfr_temp3, Precision);
 
-
-            // bool TryFastGroup = true;
-
-
             while(this_idx > PrimeQueueEpsilonStack.top().index)
             {
-
                 // Iterate
                 const uint64_t BunchSize = 64;
                 FastBigFloat<3> lhs_update_rndd;
@@ -568,9 +563,7 @@ uint64_t AddPrimeFactors()
                 FastBigFloat<3> rhs_update_rndd_test = rhs_update_rndd;
                 FastBigFloat<3> rhs_update_rndu_test = rhs_update_rndu;
 
-                while(
-///TryFastGroup and
-                   this_idx - PrimeQueueEpsilonStack.top().index >= BunchSize)
+                while(this_idx - PrimeQueueEpsilonStack.top().index >= BunchSize)
                 {
                     cnt_FastBunchMul++;
 


### PR DESCRIPTION
Roughly 12% speedup by continuing with bunches of fast multiplication before transforming back to mpfr, plus potential for further speedups later.