### PR TITLE
try larger bunches

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -548,7 +548,7 @@ uint64_t AddPrimeFactors()
             while(this_idx > PrimeQueueEpsilonStack.top().index)
             {
                 // Iterate
-                const uint64_t BunchSize = 64;
+                const uint64_t BunchSize = 128;
                 FastBigFloat<3> lhs_update_rndd;
                 lhs_update_rndd.set_ui(1);
                 FastBigFloat<3> lhs_update_rndu;


### PR DESCRIPTION
Enlarging bunch size from 64 to 128 reduces time by about 6%.