### PR TITLE
change unlikely to expect

### DIFF
--- a/FastBigFloat.hpp
+++ b/FastBigFloat.hpp
@@ -93,7 +93,7 @@ struct FastBigFloat
 
         // Then increment by one.
         sig[0]++;
-        if(sig[0] == 0) [[unlikely]]
+        if(__builtin_expect(sig[0] == 0, 0)) // [[unlikely]]
         {
             bool inc_exp = true;
             for(size_t i = 1; i < N; i++)


### PR DESCRIPTION
This version of Clang does not support unlikely, but it supports expect.  It seems to have a miniscule impact but at least it does what it is supposed to do.  When the system I'm running on supports clang 12 then unlikely should work fine and I can move to that.