### PR TITLE
Larger prime queue

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -466,7 +466,7 @@ Internally we record calculations of the critical
 epsilon, since the goal is to compute it for a very
 small subset of factors.
 */
-std::vector<uint64_t> PrimeQueue(1 << 15);
+std::vector<uint64_t> PrimeQueue(1 << 14);
 size_t NextPrimeIdx = PrimeQueue.size();
 primesieve::iterator PrimeQueueProducer;
 struct PrimeQueueEpsilonGroup

--- a/Search.cpp
+++ b/Search.cpp
@@ -466,7 +466,7 @@ Internally we record calculations of the critical
 epsilon, since the goal is to compute it for a very
 small subset of factors.
 */
-std::vector<uint64_t> PrimeQueue(8192);
+std::vector<uint64_t> PrimeQueue(1 << 14);
 size_t NextPrimeIdx = PrimeQueue.size();
 primesieve::iterator PrimeQueueProducer;
 struct PrimeQueueEpsilonGroup

--- a/Search.cpp
+++ b/Search.cpp
@@ -466,7 +466,7 @@ Internally we record calculations of the critical
 epsilon, since the goal is to compute it for a very
 small subset of factors.
 */
-std::vector<uint64_t> PrimeQueue(1 << 14);
+std::vector<uint64_t> PrimeQueue(1 << 15);
 size_t NextPrimeIdx = PrimeQueue.size();
 primesieve::iterator PrimeQueueProducer;
 struct PrimeQueueEpsilonGroup


### PR DESCRIPTION
Increasing prime queue length from 2^13 to 2^14 gives measured speedup of 5%