### PR TITLE
Tune bunch sizes

### DIFF
--- a/Search.cpp
+++ b/Search.cpp
@@ -561,7 +561,7 @@ uint64_t AddPrimeFactors()
                 rhs_update_rndu.set_ui(1);
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 8})
+                for(uint64_t BunchSize : {512, 128, 32, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -561,7 +561,7 @@ uint64_t AddPrimeFactors()
                 rhs_update_rndu.set_ui(1);
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 16})
+                for(uint64_t BunchSize : {512, 64, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 8})
+                for(uint64_t BunchSize : {512, 64, 32, 16, 8, 4})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 32, 8})
+                for(uint64_t BunchSize : {256, 64, 32, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -561,7 +561,7 @@ uint64_t AddPrimeFactors()
                 rhs_update_rndu.set_ui(1);
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {256, 16})
+                for(uint64_t BunchSize : {512, 16})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {1024, 64, 32, 8})
+                for(uint64_t BunchSize : {512, 32, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -560,6 +560,12 @@ uint64_t AddPrimeFactors()
                 FastBigFloat<3> rhs_update_rndu;
                 rhs_update_rndu.set_ui(1);
 
+                // Fast bunches have to throw away work when they
+                // advance too far, rather than just updating
+                // logarithms.  So we separately talk new bounds
+                // on how far we can advance with bunches.
+                size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
+
                 // Run with sequence bunch sizes.
                 for(uint64_t BunchSize : {512, 128, 32, 8})
                 {
@@ -569,7 +575,7 @@ uint64_t AddPrimeFactors()
                     FastBigFloat<3> rhs_update_rndd_test = rhs_update_rndd;
                     FastBigFloat<3> rhs_update_rndu_test = rhs_update_rndu;
 
-                    while(NextPrimeIdx + BunchSize - 1 <= PrimeQueueEpsilonStack.top().index)
+                    while(NextPrimeIdx + BunchSize - 1 <= MaxBunchIdx)
                     {
                         cnt_FastBunchMul++;
 
@@ -607,6 +613,8 @@ uint64_t AddPrimeFactors()
                         {
                             // Possibly LHS >= RHS.
                             // We need to drop that last bunch and go more carefully.
+                            // Reduce MaxBunchIdx so we won't try the same thing again.
+                            MaxBunchIdx = NextPrimeIdx + BunchSize - 2;
                             break;
                         }
                     }

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 32, 8})
+                for(uint64_t BunchSize : {512, 64, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 16})
+                for(uint64_t BunchSize : {512, 64, 4})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {256, 64, 32, 8})
+                for(uint64_t BunchSize : {1024, 64, 32, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 8})
+                for(uint64_t BunchSize : {512, 64, 16})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 64, 4})
+                for(uint64_t BunchSize : {512, 64, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;

--- a/Search.cpp
+++ b/Search.cpp
@@ -567,7 +567,7 @@ uint64_t AddPrimeFactors()
                 size_t MaxBunchIdx = PrimeQueueEpsilonStack.top().index;
 
                 // Run with sequence bunch sizes.
-                for(uint64_t BunchSize : {512, 128, 32, 8})
+                for(uint64_t BunchSize : {512, 64, 32, 8})
                 {
 
                     FastBigFloat<3> lhs_update_rndd_test = lhs_update_rndd;


### PR DESCRIPTION
Use a wider range of bunch sizes. Do a better job about skipping bunches that definitely won't be successful. Gets maybe 3% speedup only.